### PR TITLE
fix padding issue on first child

### DIFF
--- a/src/layouts/Header/Header.css
+++ b/src/layouts/Header/Header.css
@@ -82,7 +82,7 @@
 .nav-list li:hover {
     font-weight: 650;
 }
-
+ 
 @media (max-width: 767px) {
     .nav-list ul {
         display: flex;

--- a/src/layouts/Header/Header.css
+++ b/src/layouts/Header/Header.css
@@ -76,7 +76,7 @@
 }
 
 .nav-list ul li:first-child {
-    margin: 0 1%;
+    margin: 0 2%;
 }
 
 .nav-list li:hover {


### PR DESCRIPTION
- First child had different padding to align with name header, but makes it look uneven
- Switched to match padding apart of list